### PR TITLE
Added option for async function invocations

### DIFF
--- a/types/lookup_builder.go
+++ b/types/lookup_builder.go
@@ -16,7 +16,7 @@ import (
 // FunctionLookupBuilder alias for types.FunctionLookupBuilder
 type FunctionLookupBuilder types.FunctionLookupBuilder
 
-// GetFunctions requests the OpenFaaS gteway to return a list of all functions
+// GetFunctions requests the OpenFaaS gateway to return a list of all functions
 func (lookup *FunctionLookupBuilder) GetFunctions() ([]requests.Function, error) {
 	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/system/functions", lookup.GatewayURL), nil)
 


### PR DESCRIPTION
Hi @zeerorg,

I've added the ability to deploy functions using _cron-connector_ with an additional annotation, "async", with a value of either "true" or "false", which will invoke functions using the gateway's asynchronous function path `/async-function/` when set to "true".
Existing deployments shouldn't be affected, since the connector will assume a default value of "false" if the "async" annotation is missing. 

Please let me know if I missed anything.

@alexellis, please have a look if you think this is something which may be relevant to other users of _cron-connector_.

Thanks :smile: 